### PR TITLE
add support for 64bit integer in json processing

### DIFF
--- a/include/hydrazine/json.h
+++ b/include/hydrazine/json.h
@@ -68,7 +68,7 @@ namespace json {
 		const std::vector< Value *>& as_array() const;
 		
 		//! returns a vector of integers if the value is a dense array
-		const std::vector< int >& as_dense_array() const;
+		const std::vector< long long int >& as_dense_array() const;
 		
 		//! returns a dictionary of values if the value is an object
 		const std::map< std::string, Value *>& as_object() const;
@@ -100,6 +100,7 @@ namespace json {
 		Number();
 		Number(double real_value);
 		Number(int int_value);
+		Number(long long int int_value);
 		virtual ~Number();
 
 		virtual Value *clone() const;
@@ -149,7 +150,7 @@ namespace json {
 	class DenseArray : public Value {
 	public:
 
-		typedef std::vector< int > IntVector;
+		typedef std::vector< long long int > IntVector;
 
 		typedef IntVector::iterator iterator;
 		typedef IntVector::const_iterator const_iterator;

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -91,7 +91,7 @@ const std::vector< json::Value *>& json::Value::as_array() const {
 	throw EXCEPTION("Invalid cast");
 }
 
-const std::vector< int >& json::Value::as_dense_array() const {
+const std::vector< long long int >& json::Value::as_dense_array() const {
 	if (type == Value::DenseArray) {
 		const json::DenseArray *element = static_cast<const json::DenseArray *>(this);
 		return element->sequence;
@@ -136,6 +136,12 @@ json::Number::Number(double real_value): Value(Value::Number), number_type(Real)
 }
 
 json::Number::Number(int int_value): Value(Value::Number), number_type(Integer), 
+										 value_real(0), value_integer(int_value)  {
+
+}
+
+
+json::Number::Number(long long int int_value): Value(Value::Number), number_type(Integer), 
 										 value_real(0), value_integer(int_value)  {
 
 }
@@ -393,7 +399,7 @@ json::Value *json::Parser::parse_value(std::istream &input) {
 }
 
 json::Value *json::Parser::parse_array(std::istream &input) {
-	typedef std::deque<int> FastIntVector;
+	typedef std::deque<long long int> FastIntVector;
 	
 	FastIntVector denseSequence;
 	


### PR DESCRIPTION
change lots of containers' type so that we can use integer more than 32bit in json file without overflow